### PR TITLE
fixed url navigation conflict with express routing

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,7 +16,7 @@ app.get('/users/:username', userController.getOneUser);
 app.post('/users', userController.postUser);
 // Catch all route for redirect must be last so others can fire first! :)
 app.get('/*', (req, res) => {
-  res.redirect('/');
+  res.sendFile(path.join(__dirname, '../client/dist/index.html'));
 });
 
 module.exports = app;


### PR DESCRIPTION
Changed the '*' route at the bottom of the express app.js to serve index.html instead of redirect to '/' and now when you type in the url for a page, React Router will serve that page.