### PR TITLE
changed authMiddleware to call next instead of redirect

### DIFF
--- a/db/auth/passport.js
+++ b/db/auth/passport.js
@@ -19,7 +19,7 @@ function authMiddleware(req, res, next) {
       }
     }
   } else {
-    res.redirect('/');
+    next();
   }
 }
 module.exports.authMiddleware = authMiddleware;


### PR DESCRIPTION
I was getting redirected to the main page when I hit refresh, so I changed the redirect in the authMiddleware to `next()` and it now lets me refresh