### PR TITLE
Changed back to res.redirect('/') in auth middleware

### DIFF
--- a/db/auth/passport.js
+++ b/db/auth/passport.js
@@ -19,7 +19,8 @@ function authMiddleware(req, res, next) {
       }
     }
   } else {
-    next();
+    // sending unauthenticated user trying to access restricted pages to splash page!
+    res.redirect('/');
   }
 }
 module.exports.authMiddleware = authMiddleware;


### PR DESCRIPTION
With `next()` in the else block, the auth middleware function has lost the ability to restrict unauthenticated users on our app. Unauthenticated users (no access token in request header) will be redirected to the splash page so that they can either log in or sign up to use the app.
I recorded the demo of using `res.redirect('/')` vs `next()` - please take a look at this video.

* https://youtu.be/uFI3l2Qjl-Y this is what `next()` does.
* https://youtu.be/cefN4h7gCK0 this is what `res.redirect('/')` does.